### PR TITLE
Improved Error struct

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
       matrix:
         rust: [stable, beta]
         TARGET: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
+        feature: ["", " --features std"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -124,7 +125,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --target=${{ matrix.TARGET }}
+          args: --target=${{ matrix.TARGET }}${{ matrix.feature }}
 
   coverage:
     name: Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-...
+### Added
+
+- Added `Display` and `Error` implementation for `Error<E>`
 
 ## [0.3.1] - 2021-07-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ embedded-hal-mock = "0.7"
 
 [profile.release]
 lto = true
+
+[features]
+std = []

--- a/src/types.rs
+++ b/src/types.rs
@@ -32,7 +32,7 @@ impl<E: Display> Display for Error<E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::I2C(e) => write!(f, "I²C bus error: {}", e),
-            Error::InvalidInputData => write!(f, "Invalid input data provided")
+            Error::InvalidInputData => write!(f, "Invalid input data provided"),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -251,3 +251,34 @@ mod tests {
         assert_eq!(DEVICE_BASE_ADDRESS, addr.0);
     }
 }
+
+#[cfg(all(test, feature = "std"))]
+mod std_tests {
+    use super::*;
+    use std::format;
+
+    struct TestError;
+    impl Display for TestError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            write!(f, "test")
+        }
+    }
+
+    #[test]
+    fn test_display_implementation_invalid_input_data() {
+        let expected = "Invalid input data provided";
+        let error = Error::<TestError>::InvalidInputData;
+        let actual = format!("{}", error);
+
+        assert_eq!(expected, actual)
+    }
+
+    #[test]
+    fn test_display_implementation_i2c_error() {
+        let expected = "I²C bus error: test";
+        let error = Error::<TestError>::I2C(TestError);
+        let actual = format!("{}", error);
+
+        assert_eq!(expected, actual)
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,9 @@ use crate::config::Config;
 use core::convert::TryFrom;
 use core::fmt::{Display, Formatter};
 
+#[cfg(feature = "std")]
+extern crate std;
+
 const DEVICE_BASE_ADDRESS: u8 = 0b100_0000;
 
 /// PCA9685 PWM/Servo/LED controller.
@@ -33,6 +36,9 @@ impl<E: Display> Display for Error<E> {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl<E: std::error::Error> std::error::Error for Error<E> {}
 
 /// Output channel selection
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,7 @@
 use crate::config::Config;
 use core::convert::TryFrom;
+use core::fmt::{Display, Formatter};
+
 const DEVICE_BASE_ADDRESS: u8 = 0b100_0000;
 
 /// PCA9685 PWM/Servo/LED controller.
@@ -20,6 +22,16 @@ pub enum Error<E> {
     I2C(E),
     /// Invalid input data provided
     InvalidInputData,
+}
+
+// Implement Display for Error<E> if E also implements Display
+impl<E: Display> Display for Error<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::I2C(e) => write!(f, "I²C bus error: {}", e),
+            Error::InvalidInputData => write!(f, "Invalid input data provided")
+        }
+    }
 }
 
 /// Output channel selection


### PR DESCRIPTION
I've done 2 things to make it easier to work with the `Error` struct:

1. Implement `Display` for `Error<E>` when `E` implements `Display`
2. Added a `std` feature which implements the `std::error::Error` for `Error<E>` if `E` implements it

By doing this you can print the error in `no_std` environments and use `?` in a `std` environment.

This PR does not introduce any breaking changes.