### PR TITLE
Add support for reading back values of ON/OFF states

### DIFF
--- a/src/channels.rs
+++ b/src/channels.rs
@@ -1,9 +1,9 @@
 use crate::{hal, Channel, Error, Pca9685, Register};
 
 // Only the 12 low bits of the ON/OFF registers contain the current value.
-static ON_OFF_BITMASK: u16 = 0b0000111111111111;
+const ON_OFF_BITMASK: u16 = 0b0000111111111111;
 // The next bit then contains the overriding "full" state for the register.
-static FULL_ON_OFF_BITMASK: u16 = 0b0001000000000000;
+const FULL_ON_OFF_BITMASK: u16 = 0b0001000000000000;
 
 impl<I2C, E> Pca9685<I2C>
 where

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -117,4 +117,32 @@ where
             .map_err(Error::I2C)
             .and(Ok(data[0]))
     }
+
+    pub(crate) fn read_double_register(&mut self, address: u8) -> Result<u16, Error<E>> {
+        let mut data = [0; 2];
+
+        self.enable_auto_increment()?;
+        self.i2c
+            .write_read(self.address, &[address], &mut data)
+            .map_err(Error::I2C)?;
+
+        Ok(u16::from_le_bytes(data))
+    }
+
+    pub(crate) fn read_two_double_registers(
+        &mut self,
+        address: u8,
+    ) -> Result<(u16, u16), Error<E>> {
+        let mut data = [0; 4];
+
+        self.enable_auto_increment()?;
+        self.i2c
+            .write_read(self.address, &[address], &mut data)
+            .map_err(Error::I2C)?;
+
+        Ok((
+            u16::from_le_bytes([data[0], data[1]]),
+            u16::from_le_bytes([data[2], data[3]]),
+        ))
+    }
 }

--- a/tests/channels.rs
+++ b/tests/channels.rs
@@ -133,6 +133,17 @@ macro_rules! channels_test {
                 }
 
                 #[test]
+                fn can_get_channel_on_min() {
+                    let trans = [
+                        I2cTrans::write(DEV_ADDR, vec![Register::MODE1, MODE1_AI]),
+                        I2cTrans::write_read(DEV_ADDR, vec![Register::$reg_on], vec![0, 0])
+                    ];
+                    let mut pwm = new(&trans);
+                    assert_eq!(pwm.get_channel_on(Channel::$channel).unwrap(), 0);
+                    destroy(pwm);
+                }
+
+                #[test]
 
                 fn can_set_channel_on_max() {
                     let trans = [
@@ -141,6 +152,17 @@ macro_rules! channels_test {
                     ];
                     let mut pwm = new(&trans);
                     pwm.set_channel_on(Channel::$channel, 4095).unwrap();
+                    destroy(pwm);
+                }
+
+                #[test]
+                fn can_get_channel_on_max() {
+                    let trans = [
+                        I2cTrans::write(DEV_ADDR, vec![Register::MODE1, MODE1_AI]),
+                        I2cTrans::write_read(DEV_ADDR, vec![Register::$reg_on], vec![255, 255])
+                    ];
+                    let mut pwm = new(&trans);
+                    assert_eq!(pwm.get_channel_on(Channel::$channel).unwrap(), 4095);
                     destroy(pwm);
                 }
 
@@ -156,6 +178,17 @@ macro_rules! channels_test {
                 }
 
                 #[test]
+                fn can_get_channel_off_min() {
+                    let trans = [
+                        I2cTrans::write(DEV_ADDR, vec![Register::MODE1, MODE1_AI]),
+                        I2cTrans::write_read(DEV_ADDR, vec![Register::$reg_off], vec![0, 0])
+                    ];
+                    let mut pwm = new(&trans);
+                    assert_eq!(pwm.get_channel_off(Channel::$channel).unwrap(), 0);
+                    destroy(pwm);
+                }
+
+                #[test]
                 fn can_set_channel_off_max() {
                     let trans = [
                         I2cTrans::write(DEV_ADDR, vec![Register::MODE1, MODE1_AI]),
@@ -163,6 +196,17 @@ macro_rules! channels_test {
                     ];
                     let mut pwm = new(&trans);
                     pwm.set_channel_off(Channel::$channel, 4095).unwrap();
+                    destroy(pwm);
+                }
+
+                #[test]
+                fn can_get_channel_off_max() {
+                    let trans = [
+                        I2cTrans::write(DEV_ADDR, vec![Register::MODE1, MODE1_AI]),
+                        I2cTrans::write_read(DEV_ADDR, vec![Register::$reg_off], vec![255, 255])
+                    ];
+                    let mut pwm = new(&trans);
+                    assert_eq!(pwm.get_channel_off(Channel::$channel).unwrap(), 4095);
                     destroy(pwm);
                 }
 
@@ -191,6 +235,17 @@ macro_rules! channels_test {
                 }
 
                 #[test]
+                fn can_get_channel_full_on() {
+                    let trans = [
+                        I2cTrans::write(DEV_ADDR, vec![Register::MODE1, MODE1_AI]),
+                        I2cTrans::write_read(DEV_ADDR, vec![Register::$reg_on], vec![0, 0b0001_0000])
+                    ];
+                    let mut pwm = new(&trans);
+                    assert!(pwm.get_channel_full_on(Channel::$channel).unwrap());
+                    destroy(pwm);
+                }
+
+                #[test]
 
                 fn can_set_channel_full_off() {
                     let trans = [
@@ -211,6 +266,17 @@ macro_rules! channels_test {
                     ];
                     let mut pwm = new(&trans);
                     pwm.set_channel_on_off(Channel::$channel, 0x102, 0x304).unwrap();
+                    destroy(pwm);
+                }
+
+                #[test]
+                fn can_get_channel_full_off() {
+                    let trans = [
+                        I2cTrans::write(DEV_ADDR, vec![Register::MODE1, MODE1_AI]),
+                        I2cTrans::write_read(DEV_ADDR, vec![Register::$reg_off], vec![0, 0b0001_0000])
+                    ];
+                    let mut pwm = new(&trans);
+                    assert!(pwm.get_channel_full_off(Channel::$channel).unwrap());
                     destroy(pwm);
                 }
             }
@@ -358,5 +424,48 @@ fn can_set_all_on_off() {
         0x406, 0x407, 0x408,
     ];
     pwm.set_all_on_off(&on, &off).unwrap();
+    destroy(pwm);
+}
+
+#[test]
+fn can_get_all_on_off() {
+    #[rustfmt::skip]
+    let trans = [
+        I2cTrans::write(DEV_ADDR, vec![Register::MODE1, MODE1_AI]),
+        I2cTrans::write_read(
+            DEV_ADDR,
+            vec![Register::C0_ON_L],
+            vec![
+                  0,   0, 255, 255,
+                  1,   0,   0,   0,
+                  0,   0,   1,   0,
+                255, 255,   0,   0,
+                  0,   0, 255, 255,
+                  0,   0,   0,   0,
+                  0,   0,   1,   0,
+                  0,   0,   0,   0,
+                255, 255,   0,   0,
+                  0,   0,   0,   0,
+                  0,   0,   0,   0,
+                  0,   0,   0,   0,
+                  0,   0,   0,   0,
+                  0,   0,   0,   0,
+                  0,   0,   0,   0,
+                  0,   0,   0,   0,
+            ],
+        ),
+    ];
+
+    let mut pwm = new(&trans);
+
+    #[rustfmt::skip]
+    assert_eq!(
+        pwm.get_all_on_off().unwrap(),
+        (
+            [   0,    1,    0, 4095,    0,    0,    0,    0, 4095, 0, 0, 0, 0, 0, 0, 0],
+            [4095,    0,    1,    0, 4095,    0,    1,    0,    0, 0, 0, 0, 0, 0, 0, 0]
+        )
+    );
+
     destroy(pwm);
 }


### PR DESCRIPTION
Hi, first off thank you for your library it is very useful.
While building something with it I realised it might be helpful to read back the current state of the ON/OFF states. So this PR adds this functionality to the library. I added a couple methods matching the setters and also added tests for them.

I do have pretty much no experience with the bitfiddly bits of rust programming though, so if anything needs improvement I'll gladly adjust the code :)