### PR TITLE
Use maybe-async-cfg to add async support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.62.0]
+        rust: [stable, 1.75.0]
         TARGET:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added `Display`, `Error` and common trait implementations for `Error<E>`.
 - Added common trait implementations for types.
+- Async support based on `embedded-hal-async` 1.0 behind `async` feature flag.
 
 ### Changed
 - [breaking-change] Removed `Default` implementation for `Pca9685` struct.
-- Raised MSRV to 1.62.0.
+- Raised MSRV to 1.75.0.
 - [breaking-change] Updated `embedded-hal` dependency to 1.0.
 
 ## [0.3.1] - 2021-07-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - [breaking-change] Removed `Default` implementation for `Pca9685` struct.
 - Raised MSRV to 1.62.0.
+- [breaking-change] Updated `embedded-hal` dependency to 1.0.
 
 ## [0.3.1] - 2021-07-14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ include = [
 edition = "2018"
 
 [dependencies]
-embedded-hal = "0.2.5"
+embedded-hal = "1.0"
 nb = "1"
 
 [dev-dependencies]
-linux-embedded-hal = "0.3"
-embedded-hal-mock = "0.7"
+linux-embedded-hal = "0.4"
+embedded-hal-mock = { version = "0.10", default-features = false, features = ["eh1"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ edition = "2018"
 [dependencies]
 embedded-hal = "1.0"
 nb = "1"
+embedded-hal-async = { version = "1", optional = true }
+maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]
 linux-embedded-hal = "0.4"
@@ -33,3 +35,4 @@ lto = true
 
 [features]
 std = []
+async = ["dep:embedded-hal-async"]

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -2,7 +2,7 @@ use crate::{hal, Channel, Error, Pca9685, Register};
 
 impl<I2C, E> Pca9685<I2C>
 where
-    I2C: hal::blocking::i2c::Write<Error = E> + hal::blocking::i2c::WriteRead<Error = E>,
+    I2C: hal::i2c::I2c<Error = E>,
 {
     /// Set the `ON` counter for the selected channel.
     ///

--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -1,13 +1,13 @@
 use crate::{
     config::{BitFlagMode1, BitFlagMode2, Config},
-    hal::{blocking::delay::DelayUs, blocking::i2c},
+    hal::{delay::DelayNs, i2c},
     Address, DisabledOutputValue, Error, OutputDriver, OutputLogicState, OutputStateChange,
     Pca9685, ProgrammableAddress, Register,
 };
 
 impl<I2C, E> Pca9685<I2C>
 where
-    I2C: i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Create a new instance of the device.
     pub fn new<A: Into<Address>>(i2c: I2C, address: A) -> Result<Self, Error<E>> {
@@ -55,11 +55,11 @@ where
     ///
     /// This includes a delay of 500us in order for the oscillator to stabilize.
     /// If you cannot afford a 500us delay you can use `restart_nonblocking()`.
-    pub fn restart(&mut self, delay: &mut impl DelayUs<u16>) -> Result<(), Error<E>> {
+    pub fn restart(&mut self, delay: &mut impl DelayNs) -> Result<(), Error<E>> {
         let mode1 = self.read_register(Register::MODE1)?;
         if (mode1 & BitFlagMode1::Restart as u8) != 0 {
             self.enable()?;
-            delay.delay_us(500_u16);
+            delay.delay_us(500);
             let previous = self.config;
             let config = previous.with_high(BitFlagMode1::Restart);
             self.write_mode1(config)?;

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{BitFlagMode1, Config},
-    hal::blocking::i2c,
+    hal::i2c,
     Error, Pca9685,
 };
 
@@ -51,7 +51,7 @@ impl Register {
 
 impl<I2C, E> Pca9685<I2C>
 where
-    I2C: i2c::Write<Error = E> + i2c::WriteRead<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     pub(crate) fn write_mode2(&mut self, config: Config) -> Result<(), Error<E>> {
         self.i2c

--- a/src/register_access.rs
+++ b/src/register_access.rs
@@ -1,8 +1,12 @@
 use crate::{
     config::{BitFlagMode1, Config},
-    hal::i2c,
     Error, Pca9685,
 };
+
+#[cfg(not(feature = "async"))]
+use embedded_hal::i2c::I2c;
+#[cfg(feature = "async")]
+use embedded_hal_async::i2c::I2c as AsyncI2c;
 
 pub struct Register;
 impl Register {
@@ -49,42 +53,53 @@ impl Register {
     pub const PRE_SCALE: u8 = 0xFE;
 }
 
+#[maybe_async_cfg::maybe(
+    sync(
+        cfg(not(feature = "async")),
+        self = "Pca9685",
+        idents(AsyncI2c(sync = "I2c"))
+    ),
+    async(feature = "async", keep_self)
+)]
 impl<I2C, E> Pca9685<I2C>
 where
-    I2C: i2c::I2c<Error = E>,
+    I2C: AsyncI2c<Error = E>,
 {
-    pub(crate) fn write_mode2(&mut self, config: Config) -> Result<(), Error<E>> {
+    pub(crate) async fn write_mode2(&mut self, config: Config) -> Result<(), Error<E>> {
         self.i2c
             .write(self.address, &[Register::MODE2, config.mode2])
+            .await
             .map_err(Error::I2C)?;
         self.config.mode2 = config.mode2;
         Ok(())
     }
 
-    pub(crate) fn write_mode1(&mut self, config: Config) -> Result<(), Error<E>> {
+    pub(crate) async fn write_mode1(&mut self, config: Config) -> Result<(), Error<E>> {
         self.i2c
             .write(self.address, &[Register::MODE1, config.mode1])
+            .await
             .map_err(Error::I2C)?;
         self.config.mode1 = config.mode1;
         Ok(())
     }
 
-    pub(crate) fn enable_auto_increment(&mut self) -> Result<(), Error<E>> {
+    pub(crate) async fn enable_auto_increment(&mut self) -> Result<(), Error<E>> {
         if self.config.is_low(BitFlagMode1::AutoInc) {
             let config = self.config;
             self.write_mode1(config.with_high(BitFlagMode1::AutoInc))
+                .await
         } else {
             Ok(())
         }
     }
 
-    pub(crate) fn write_two_double_registers(
+    pub(crate) async fn write_two_double_registers(
         &mut self,
         address: u8,
         value0: u16,
         value1: u16,
     ) -> Result<(), Error<E>> {
-        self.enable_auto_increment()?;
+        self.enable_auto_increment().await?;
         self.i2c
             .write(
                 self.address,
@@ -96,24 +111,27 @@ where
                     (value1 >> 8) as u8,
                 ],
             )
+            .await
             .map_err(Error::I2C)
     }
 
-    pub(crate) fn write_double_register(
+    pub(crate) async fn write_double_register(
         &mut self,
         address: u8,
         value: u16,
     ) -> Result<(), Error<E>> {
-        self.enable_auto_increment()?;
+        self.enable_auto_increment().await?;
         self.i2c
             .write(self.address, &[address, value as u8, (value >> 8) as u8])
+            .await
             .map_err(Error::I2C)
     }
 
-    pub(crate) fn read_register(&mut self, address: u8) -> Result<u8, Error<E>> {
+    pub(crate) async fn read_register(&mut self, address: u8) -> Result<u8, Error<E>> {
         let mut data = [0];
         self.i2c
             .write_read(self.address, &[address], &mut data)
+            .await
             .map_err(Error::I2C)
             .and(Ok(data[0]))
     }

--- a/tests/addressing.rs
+++ b/tests/addressing.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 use pwm_pca9685::{Address, ProgrammableAddress as ProgAddr};
 
 mod common;

--- a/tests/channels.rs
+++ b/tests/channels.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 use pwm_pca9685::Channel;
 use std::convert::TryFrom;
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
+use embedded_hal_mock::eh1::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 use pwm_pca9685::{Address, Error, Pca9685};
 
 #[allow(unused)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 use pwm_pca9685::{DisabledOutputValue, OutputDriver, OutputLogicState, OutputStateChange};
 
 mod common;

--- a/tests/restart.rs
+++ b/tests/restart.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::{delay::MockNoop as DelayMock, i2c::Transaction as I2cTrans};
+use embedded_hal_mock::eh1::{delay::NoopDelay as DelayMock, i2c::Transaction as I2cTrans};
 use pwm_pca9685::ProgrammableAddress as ProgAddr;
 
 mod common;


### PR DESCRIPTION
Superseeds #14 , #13 

Also, update to embedded-hal v1 so that there is only one trait for I2C on both sides.

Closes #15 
Closes #11 

Heavily inspired by https://github.com/eldruin/tcs3472-rs/pull/5

I could not make the example in `lib.rs` compile, even when adding the embassy dependencies, because I cannot figure out how to enable a feature for a single doctest. So I did not include the embassy deps.