### PR TITLE
Allow setting full-on and full-off bits via set_all_on_off()

### DIFF
--- a/src/channels.rs
+++ b/src/channels.rs
@@ -93,6 +93,14 @@ where
     /// Set the `ON` and `OFF` counter for each channel at once.
     ///
     /// The index of the value in the arrays corresponds to the channel: 0-15.
+    /// The `on` and `off` value for each channel sets the counter value
+    /// (0-4095) for switching the respective channel on and off during each PWM
+    /// cycle. In addition, the 13th bit of an `on` value (i.e. values
+    /// 4096-8191) sets the respective channel to *full on*; the remainder
+    /// of the value defining the switch-on-delay in the initial PWM cycle.
+    /// Similarly, the special value 4096 in the `off` array sets a channel to
+    /// *full off*.
+    ///
     /// Note that the full off setting takes precedence over the `on` settings.
     /// See section 7.3.3 "LED output and PWM control" of the datasheet for
     /// further details.
@@ -104,7 +112,7 @@ where
         let mut data = [0; 65];
         data[0] = Register::C0_ON_L;
         for (i, (on, off)) in on.iter().zip(off).enumerate() {
-            if *on > 4095 || *off > 4095 {
+            if *on > 8191 || *off > 4096 {
                 return Err(Error::InvalidInputData);
             }
             data[i * 4 + 1] = *on as u8;

--- a/tests/channels.rs
+++ b/tests/channels.rs
@@ -84,7 +84,7 @@ invalid_test!(
 invalid_test!(
     cannot_set_all_on_off_invalid_value_on,
     set_all_on_off,
-    &[4096; 16],
+    &[8192; 16],
     &[0; 16]
 );
 
@@ -92,7 +92,7 @@ invalid_test!(
     cannot_set_all_on_off_invalid_value_off,
     set_all_on_off,
     &[0; 16],
-    &[4096; 16]
+    &[4097; 16]
 );
 
 #[test]
@@ -338,24 +338,25 @@ fn can_set_all_on_off() {
                 6,
                 4,
                 5,
-                2,
+                18,
                 7,
                 4,
                 6,
                 2,
-                8,
-                4,
+                0,
+                16,
             ],
         ),
     ];
     let mut pwm = new(&trans);
+    // 2nd-last channel: full-on with delay, last channel: full-off
     let on = [
         0x101, 0x102, 0x103, 0x104, 0x105, 0x106, 0x107, 0x108, 0x109, 0x200, 0x201, 0x202, 0x203,
-        0x204, 0x205, 0x206,
+        0x204, 0x1205, 0x206,
     ];
     let off = [
         0x303, 0x304, 0x305, 0x306, 0x307, 0x308, 0x309, 0x400, 0x401, 0x402, 0x403, 0x404, 0x405,
-        0x406, 0x407, 0x408,
+        0x406, 0x407, 0x1000,
     ];
     pwm.set_all_on_off(&on, &off).unwrap();
     destroy(pwm);


### PR DESCRIPTION
## Problem

I use the PCA9685 for driving multichannel LED strips with animations. In every animation step, I update all on/off values with `set_all_on_off()` and afterwards use `set_channel_full_on()` resp. `set_channel_full_off()` for all channels that shall be full on/off. This got me issues with visible flickering of the full on/off channels.

Thus, I want to be able to update all channels' on/off counter values *and* the full-on and full-off bits in a single I2C transaction.

## Solution

I extended the allowed range of values in the slice arguments of `set_all_on_off()`, so it's possible to set the 13th bit (the full-on/full-off bit) for each individual channel. This is a backwards-compatible change.

## Alternatives

If you don't like the relaxed range check of the on/off values in the existing `set_all_on_off()` method, because of its mixed-up value semantics (I understand that setting a channel to full-off is semantically different from setting the off counter value), I can refactor the PR to add another method for this combined functionality. (Any ideas for the name?)

This separate method could also take two additional `&[bool; 16]` slices for the full-on/full-off values, but I considered this is a bit inefficient and rather unergonomically to use. 

Alternatively, I thought about adding public constants `FULL_ON_BIT: u16` and `FULL_OFF_VALUE: u16` to make the new combined functionality of  `set_all_on_off()` easier to use.